### PR TITLE
not all results have 'dn'

### DIFF
--- a/pyramid_ldap3/__init__.py
+++ b/pyramid_ldap3/__init__.py
@@ -64,7 +64,7 @@ class _LDAPQuery(object):
             if result is None:
                 result = []
             else:
-                result = [(r['dn'], r['attributes']) for r in result]
+                result = [(r['dn'], r['attributes']) for r in result if 'dn' in r]
                 self.cache[cache_key] = result
         else:
             logger.debug('result for %r retrieved from cache', cache_key)


### PR DESCRIPTION
On the local AD/LDAP system, authenticate(login, pass) produces a result list of length 4 and only the first item is the user info of interest, the other 3 look more or less like:

{'type': 'searchResRef', 'uri': ['ldaps://zone.some.lan/DC=zone,DC=some,DC=lan']}
{'type': 'searchResRef', 'uri': ['ldaps://otherzone.some.lan/DC=otherzone,DC=some,DC=lan']}
{'type': 'searchResRef', 'uri': ['ldaps://some.lan/CN=Configuration,DC=some,DC=lan']}

Patch fixes the "key error" issue for me.
