### PR TITLE
set get_info=ldap3.NONE on Server objects

### DIFF
--- a/pyramid_ldap3/__init__.py
+++ b/pyramid_ldap3/__init__.py
@@ -128,7 +128,7 @@ class ConnectionManager(object):
             except ValueError:
                 host, port = host, 636 if use_ssl else 389
             server = self.ldap3.Server(
-                host, port=port, use_ssl=use_ssl, tls=tls)
+                host, port=port, use_ssl=use_ssl, tls=tls, get_info=ldap3.NONE)
             servers.append(server)
         self.server = servers[
             0] if len(servers) == 1 else self.ldap3.ServerPool(servers)


### PR DESCRIPTION
When connecting, if `get_info` isn't set to `ldap3.NONE` it will try and load the schema for the directory, which when simply wanted to check authentication with static queries seems overkill.